### PR TITLE
feat: Add buttons hover states

### DIFF
--- a/app/frontend/static landing page.html
+++ b/app/frontend/static landing page.html
@@ -505,6 +505,28 @@ body {
   transition: background .15s; display: inline-flex; align-items: center; gap: 6px;
 }
 .dl-btn:hover { background: var(--c-surface); }
+
+/* ── Tooltips ── */
+.has-tooltip { position: relative; }
+.has-tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--c-black);
+  color: var(--c-white);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .15s;
+}
+.has-tooltip:hover::after { opacity: 1; }
+
 </style>
 </head>
 <body>
@@ -525,7 +547,7 @@ body {
       <a href="#">Docs</a>
     </div>
     <button class="theme-toggle" onclick="toggleTheme()" id="themeBtn" title="Toggle dark/light mode">☀️</button>
-    <button class="nav-cta" onclick="showUpload()">Get started</button>
+    <button class="nav-cta has-tooltip" data-tooltip="Upload your sensor data" onclick="showUpload()">Get started</button>
   </nav>
 
   <section class="hero">
@@ -533,7 +555,7 @@ body {
     <h1 class="headline">Catch pump failures <em>30 minutes</em> before they happen.</h1>
     <p class="hero-sub">A drop-in early-warning layer for industrial centrifugal pumps. Upload sensor data, run pre-trained anomaly models, and know exactly when to intervene — no data science team required.</p>
     <div class="cta-row">
-      <button class="cta-p" onclick="showUpload()">Try it with your data →</button>
+      <button class="cta-p has-tooltip" data-tooltip="Upload a CSV and run anomaly detection" onclick="showUpload()">Try it with your data →</button>
       <button class="cta-s">See it in action</button>
     </div>
     <div class="mockup-wrap">
@@ -729,7 +751,7 @@ body {
 
     <!-- Step 3: Run -->
     <div class="sec-eyebrow">— step 3 · run prediction</div>
-    <button class="run-btn" id="runBtn" disabled>
+    <button class="run-btn has-tooltip" data-tooltip="Upload a CSV file first to enable" id="runBtn" disabled>
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg>
       Run prediction
     </button>
@@ -743,7 +765,7 @@ body {
 2020-01-01 00:00:00,0.412,0.398,...,0.541,0
 2020-01-01 00:00:01,0.419,0.401,...,0.538,0
 2020-01-01 00:00:02,0.445,0.388,...,0.612,1</div>
-    <button class="dl-btn">
+    <button class="dl-btn has-tooltip" data-tooltip="Download a sample SKAB-format CSV">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
       Download sample CSV
     </button>

--- a/app/frontend/static landing page.html
+++ b/app/frontend/static landing page.html
@@ -30,6 +30,25 @@
   --r-pill:        100px;
 }
 
+/* ── Dark theme ── */
+[data-theme="dark"] {
+  --c-bg:         #1a1a1a;
+  --c-surface:    #242424;
+  --c-border:     rgba(255,255,255,0.1);
+  --c-border-med: rgba(255,255,255,0.2);
+  --c-text:       #f0f0f0;
+  --c-muted:      #9ca3af;
+  --c-hint:       #6b7280;
+  --c-black:      #f0f0f0;
+  --c-white:      #1a1a1a;
+  --c-blue-bg:    #1e2a4a;
+  --c-amber-bg:   #2a1f0a;
+}
+
+[data-theme="dark"] body {
+  background: #111111;
+}
+
 body {
   font-family: 'Plus Jakarta Sans', sans-serif;
   background: #f4f4f3;
@@ -83,6 +102,18 @@ body {
   border: none; cursor: pointer; transition: opacity .15s;
 }
 .nav-cta:hover { opacity: 0.82; }
+
+/* ── Theme toggle ── */
+.theme-toggle {
+  background: none;
+  border: 0.5px solid var(--c-border-med);
+  border-radius: var(--r-md);
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background .15s;
+}
+.theme-toggle:hover { background: var(--c-surface); }
 
 /* ── Hero ── */
 .hero {
@@ -493,6 +524,7 @@ body {
       <a href="#">How it works</a>
       <a href="#">Docs</a>
     </div>
+    <button class="theme-toggle" onclick="toggleTheme()" id="themeBtn" title="Toggle dark/light mode">☀️</button>
     <button class="nav-cta" onclick="showUpload()">Get started</button>
   </nav>
 
@@ -596,6 +628,7 @@ body {
       <a href="#" onclick="showLanding();return false;">← Back to home</a>
       <a href="#">Docs</a>
     </div>
+    <button class="theme-toggle" onclick="toggleTheme()" id="themeBtnUpload" title="Toggle dark/light mode">☀️</button>
     <button class="nav-cta" onclick="showUpload()">Upload</button>
   </nav>
 
@@ -726,6 +759,25 @@ body {
 </div><!-- /page -->
 
 <script>
+
+// ── Theme toggle ──
+function toggleTheme() {
+  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+  document.documentElement.setAttribute('data-theme', isDark ? 'light' : 'dark');
+  document.getElementById('themeBtn').textContent = isDark ? '☀️' : '🌙';
+  localStorage.setItem('theme', isDark ? 'light' : 'dark');
+}
+
+// Apply saved theme on load
+(function() {
+  const saved = localStorage.getItem('theme');
+  if (saved) {
+    document.documentElement.setAttribute('data-theme', saved);
+    const btn = document.getElementById('themeBtn');
+    if (btn) btn.textContent = saved === 'dark' ? '🌙' : '☀️';
+  }
+})();
+
 // ── Page navigation ──
 function showUpload() {
   document.getElementById('landing').classList.add('hidden');


### PR DESCRIPTION
This PR adds tooltips to all primary interactive buttons across the landing and upload pages to improve usability for new users.

**What's included:**
- .has-tooltip CSS class using ::after pseudo-element to display tooltip text on hover
- data-tooltip attributes added to: Get started, Try it with your data, Run prediction, Download sample CSV
- Tooltip styled using existing design tokens (--c-black, --c-white, JetBrains Mono)