### PR TITLE
Add basic error message for invalid CSV schema on upload

### DIFF
--- a/app/frontend/static landing page.html
+++ b/app/frontend/static landing page.html
@@ -474,6 +474,23 @@ body {
   transition: background .15s; display: inline-flex; align-items: center; gap: 6px;
 }
 .dl-btn:hover { background: var(--c-surface); }
+
+/* ── Basic error message ── */
+.upload-error {
+  display: none;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #dc2626;
+  background: #fef2f2;
+  padding: 10px 14px;
+  border-radius: var(--r-md);
+  border: 0.5px solid #fecaca;
+  margin-bottom: 1rem;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+}
+.upload-error.visible { display: flex; }
+
 </style>
 </head>
 <body>
@@ -622,6 +639,11 @@ body {
       <div class="drop-hint">CSV · SKAB FORMAT · 26 SENSOR CHANNELS · UTF-8</div>
     </div>
 
+    <!-- Error message -->
+    <div class="upload-error" id="uploadError">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#dc2626" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+      <span id="uploadErrorMsg">Invalid file. Please upload a CSV file.</span>
+    </div>
     <!-- File preview -->
     <div class="file-preview" id="filePreview">
       <div class="fp-icon">
@@ -744,18 +766,34 @@ const dz = document.getElementById('dropZone');
 function handleFile(input) {
   const file = input.files[0];
   if (!file) return;
-  document.getElementById('fileName').textContent = file.name;
-  document.getElementById('fileSize').textContent = (file.size / 1024).toFixed(1) + ' KB';
-  document.getElementById('filePreview').classList.add('visible');
-  document.getElementById('validationOk').classList.add('visible');
-  document.getElementById('runBtn').disabled = false;
-  dz.classList.add('file-loaded');
+  document.getElementById('uploadError').classList.remove('visible');
+  const reader = new FileReader();
+  reader.onload = function(e) {
+    const firstLine = e.target.result.split('\n')[0].toLowerCase();
+    const requiredCols = ['datetime', 'sensor_00', 'label'];
+    const missing = requiredCols.filter(col => !firstLine.includes(col));
+    if (missing.length > 0) {
+      document.getElementById('uploadErrorMsg').textContent = `Invalid schema — missing columns: ${missing.join(', ')}. Please check the required format.`;
+      document.getElementById('uploadError').classList.add('visible');
+      document.getElementById('runBtn').disabled = true;
+      return;
+    }
+    document.getElementById('uploadError').classList.remove('visible');
+    ocument.getElementById('fileName').textContent = file.name;
+    document.getElementById('fileSize').textContent = (file.size / 1024).toFixed(1) + ' KB';
+    document.getElementById('filePreview').classList.add('visible');
+    document.getElementById('validationOk').classList.add('visible');
+    document.getElementById('runBtn').disabled = false;
+    dz.classList.add('file-loaded');
+  };
+  reader.readAsText(file.slice(0, 500));
 }
 
 function clearFile() {
   document.getElementById('fileInput').value = '';
   document.getElementById('filePreview').classList.remove('visible');
   document.getElementById('validationOk').classList.remove('visible');
+  document.getElementById('uploadError').classList.remove('visible');
   document.getElementById('runBtn').disabled = true;
   dz.classList.remove('file-loaded');
 }


### PR DESCRIPTION
Now that users can upload CSV files, a clear error message is needed when the uploaded file does not match the required SKAB schema. This PR adds schema validation on file upload, checking for required columns and showing an error message if they are missing.

What's included:
- Schema validation checking for required columns: datetime, sensor_00, label
- Red error banner displayed with details of missing columns
- Run Prediction button disabled when schema is invalid
- Error clears when file is removed