### PR TITLE
Add sample CSV download component

### DIFF
--- a/app/frontend/components/sample_csv_download/sample_csv_download.css
+++ b/app/frontend/components/sample_csv_download/sample_csv_download.css
@@ -1,0 +1,147 @@
+
+
+/* ─── outer card ────────────────────────────────────────────── */
+.sample-download-card {
+  border: 0.5px solid var(--c-border);
+  border-radius: var(--r-lg);
+  padding: 1.25rem 1.5rem;
+  background: var(--c-bg);
+  margin-bottom: 10px;
+  transition: box-shadow 0.2s ease;
+}
+
+.sample-download-card:hover {
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
+}
+
+
+/* ─── header row ─────────────────────────────────────────────── */
+.sdc-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.sdc-title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--c-text);
+}
+
+/* small pill showing the file format */
+.sdc-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  font-weight: 500;
+  color: var(--c-blue);
+  background: var(--c-blue-bg);
+  padding: 3px 10px;
+  border-radius: var(--r-pill);
+  letter-spacing: 0.06em;
+}
+
+
+/* ─── description line ───────────────────────────────────────── */
+.sdc-sub {
+  font-size: 13px;
+  color: var(--c-muted);
+  line-height: 1.55;
+  margin-bottom: 0.875rem;
+}
+
+
+/* ─── code preview block ─────────────────────────────────────── */
+.sdc-preview {
+  margin-bottom: 1rem;
+}
+
+.sdc-preview-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  color: var(--c-hint);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.sdc-code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  background: var(--c-surface);
+  border: 0.5px solid var(--c-border);
+  border-radius: var(--r-md);
+  padding: 10px 12px;
+  line-height: 1.7;
+  color: var(--c-text);
+  white-space: pre;
+  overflow-x: auto;
+}
+
+
+/* ─── footer: file info + download button ────────────────────── */
+.sdc-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.sdc-file-name {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--c-text);
+  font-weight: 500;
+  margin-bottom: 2px;
+}
+
+.sdc-file-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  color: var(--c-hint);
+  letter-spacing: 0.04em;
+}
+
+/* download button - matches the existing .dl-btn style on the page */
+.sdc-dl-btn {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: var(--r-pill);
+  background: transparent;
+  color: var(--c-text);
+  border: 0.5px solid var(--c-border-med);
+  cursor: pointer;
+  transition: background 0.15s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.sdc-dl-btn:hover {
+  background: var(--c-surface);
+}
+
+.sdc-dl-btn:active {
+  /* brief feedback when clicked */
+  background: var(--c-blue-bg);
+  border-color: var(--c-blue);
+  color: var(--c-blue);
+}
+
+
+/* ─── mobile ─────────────────────────────────────────────────── */
+@media (max-width: 480px) {
+  .sdc-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .sdc-dl-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/app/frontend/components/sample_csv_download/sample_csv_download.html
+++ b/app/frontend/components/sample_csv_download/sample_csv_download.html
@@ -1,0 +1,57 @@
+<!--
+  
+
+  Why this matters: the upload page already shows the column names as
+  pills, but seeing them in a real file with actual sensor values is
+  much more helpful for someone who has never worked with SKAB data.
+
+  The card has:
+    - a short explanation of what the file contains
+    - a preview of the first couple of rows so users can see the format
+    - a download button that triggers the file save
+
+  Three files make up this component:
+    - sample_csv_download.html  → this file (the markup)
+    - sample_csv_download.css   → styling
+    - sample_csv_download.js    → download button logic
+    - sample_skab_format.csv    → the actual file users download
+-->
+
+<section class="sample-download-card">
+
+  <!-- header row: title + format badge -->
+  <div class="sdc-head">
+    <div class="sdc-title">Download sample data file</div>
+    <div class="sdc-badge">SKAB FORMAT</div>
+  </div>
+
+  <!-- one-line explanation -->
+  <p class="sdc-sub">
+    Not sure how to format your CSV? Download this example file — it uses
+    real valve sensor readings from the SKAB dataset so you can see exactly
+    what columns and values are expected.
+  </p>
+
+  <!-- mini preview of the file so users can see the format before downloading -->
+  <div class="sdc-preview">
+    <div class="sdc-preview-label">Preview — first 3 rows</div>
+    <div class="sdc-code">datetime;Accelerometer1RMS;...;anomaly
+2020-03-09 10:14:33;0.02658;...;0.0
+2020-03-09 10:14:34;0.02616;...;0.0</div>
+  </div>
+
+  <!-- file info row + download button -->
+  <div class="sdc-footer">
+    <div class="sdc-file-info">
+      <div class="sdc-file-name">sample_skab_format.csv</div>
+      <div class="sdc-file-meta">10 rows · 11 columns · semicolon-delimited · UTF-8</div>
+    </div>
+    <button class="sdc-dl-btn" id="sdcDownloadBtn" onclick="downloadSampleCSV()">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+        <path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/>
+      </svg>
+      Download
+    </button>
+  </div>
+
+</section>

--- a/app/frontend/components/sample_csv_download/sample_csv_download.js
+++ b/app/frontend/components/sample_csv_download/sample_csv_download.js
@@ -1,0 +1,63 @@
+
+
+
+/*
+  downloadSampleCSV - called by the onclick on the download button.
+  Fetches the sample file and triggers a browser download.
+*/
+function downloadSampleCSV() {
+  const btn      = document.getElementById("sdcDownloadBtn");
+  const filePath = "components/sample_csv_download/sample_skab_format.csv";
+  const fileName = "sample_skab_format.csv";
+
+  // give the user some feedback that something is happening
+  const originalText = btn.innerHTML;
+  btn.innerHTML = `
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <circle cx="12" cy="12" r="10"/>
+    </svg>
+    Downloading...
+  `;
+  btn.disabled = true;
+
+  fetch(filePath)
+    .then(response => {
+      if (!response.ok) {
+        throw new Error("File not found");
+      }
+      return response.blob();
+    })
+    .then(blob => {
+      // create a temporary invisible link and click it to trigger download
+      const url  = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href     = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+
+      // restore button after a short delay
+      setTimeout(() => {
+        btn.innerHTML = originalText;
+        btn.disabled  = false;
+      }, 1500);
+    })
+    .catch(() => {
+      // if fetch fails (e.g. running locally without a server),
+      // fall back to a direct anchor download
+      const link    = document.createElement("a");
+      link.href     = filePath;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      btn.innerHTML = originalText;
+      btn.disabled  = false;
+    });
+}
+
+// expose to global so the onclick in the HTML can find it
+window.downloadSampleCSV = downloadSampleCSV;


### PR DESCRIPTION
Adds a download card to the upload page that gives users a correctly formatted example CSV file before they try uploading their own data.

The card shows a short description, a preview of the first few rows so users can see the format at a glance, and a download button that triggers the file save. Built as separate HTML, CSS and JS files under app/frontend/components/sample_csv_download/.

To wire up: link the CSS in head, paste the component HTML near the file format section, and add the JS script tag before closing body.

Closes #55