### PR TITLE
Docs: add D3 handover guides

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,398 @@
+# pump.detect Developer Guide
+
+CITS5206 Information Technology Capstone Project — Group 14  
+Predictive Maintenance Anomaly Detection for Industrial Pumps
+
+## 1. Purpose
+
+This document provides developer-focused handover notes for the `pump.detect` project. It explains the codebase structure, main modules, model integration, API responsibilities, frontend responsibilities, development workflow, testing expectations, and known technical limitations.
+
+Setup and running instructions are provided separately in the project README.
+
+---
+
+## 2. Repository Overview
+
+The repository is organised into application code, machine learning scripts, data folders, and documentation.
+
+```text
+predictive_maintenance_anomaly_detection/
+├── app/
+├── data/
+├── docs/
+├── src/
+├── .gitignore
+├── README.md
+├── requirements.txt
+└── SKAB_Preprocessing_README.md
+```
+
+| Path | Purpose |
+|---|---|
+| `app/` | Deployable web application containing backend, frontend, scripts, and app-level documentation |
+| `data/` | Raw and processed dataset folders |
+| `docs/` | Handover documentation such as user guide, developer guide, and deployment guide |
+| `src/` | Offline preprocessing and model training scripts |
+| `README.md` | Main project overview and workflow |
+| `requirements.txt` | Python dependencies for model training and preprocessing |
+| `SKAB_Preprocessing_README.md` | Notes for SKAB dataset preprocessing |
+
+---
+
+## 3. Application Structure
+
+The main web application is located in the `app/` folder.
+
+```text
+app/
+├── backend/
+├── frontend/
+├── scripts/
+├── docker-compose.yml
+├── README.md
+└── CONTRIBUTING.md
+```
+
+| Path | Purpose |
+|---|---|
+| `app/backend/` | FastAPI backend for upload validation, model inference, live monitoring, streaming, and report generation |
+| `app/frontend/` | React/Vite frontend for the user interface |
+| `app/scripts/` | Utility scripts, including the local pump simulator |
+| `app/docker-compose.yml` | Application container configuration |
+| `app/README.md` | Application-level setup notes |
+| `app/CONTRIBUTING.md` | Contribution and implementation notes |
+
+---
+
+## 4. Backend Responsibilities
+
+The backend is responsible for the system logic behind prediction, validation, streaming, and reporting.
+
+Main backend responsibilities:
+
+- Validate uploaded CSV files.
+- Check the required SKAB sensor schema.
+- Load trained machine learning model artifacts.
+- Run batch prediction on uploaded files.
+- Compare prediction outputs across multiple models.
+- Stream replay results to the frontend.
+- Receive live or simulated sensor readings.
+- Convert prediction probabilities into alert states.
+- Generate downloadable PDF reports.
+- Provide API endpoints for frontend communication.
+
+The backend should keep validation, model loading, inference, live state handling, and report generation separated so that future changes can be made without rewriting the full application.
+
+---
+
+## 5. Frontend Responsibilities
+
+The frontend provides the user-facing interface for the project.
+
+Main frontend responsibilities:
+
+- Show the landing/home page.
+- Allow users to upload CSV files.
+- Display clear upload success and error messages.
+- Allow users to select a model.
+- Allow users to adjust the anomaly threshold.
+- Display anomaly probability charts.
+- Show alert states such as NORMAL, WATCH, WARNING, and ALERT.
+- Display model comparison results.
+- Support live monitoring views.
+- Allow users to download PDF reports.
+
+Frontend features should always give clear feedback for loading, success, and error states so that non-technical users can understand what is happening.
+
+---
+
+## 6. Machine Learning Pipeline
+
+The machine learning pipeline is stored mainly in the `src/` folder.
+
+The final system uses SKAB pump sensor data as the main dataset. The ML pipeline includes:
+
+- SKAB dataset preprocessing.
+- Training and validation splits.
+- Classical machine learning baselines.
+- Boosting models.
+- TransformerFusionLite deep learning model.
+- Exporting trained artifacts for backend inference.
+
+Models used in the final system include:
+
+| Model | Type |
+|---|---|
+| Logistic Regression | Linear baseline |
+| Random Forest | Tree-based model |
+| Extra Trees | Tree-based ensemble |
+| Gradient Boosting | Boosting model |
+| XGBoost | Boosting model |
+| KNN | Instance-based model |
+| SVM | Support vector machine |
+| TransformerFusionLite | Deep learning model |
+
+The TransformerFusionLite model achieved the strongest reported final result, with F1 = 0.9244 on the SKAB held-out test set.
+
+---
+
+## 7. Model Artifact Integration
+
+The backend requires trained model artifacts to perform inference.
+
+Expected artifact folder:
+
+```text
+app/backend/artifacts/
+```
+
+Typical model artifacts include:
+
+```text
+scaler.pkl
+transformer_scaler.pkl
+sample.csv
+model_lr.pkl
+model_rf.pkl
+model_svm.pkl
+model_et.pkl
+model_gb.pkl
+model_knn.pkl
+model_xgb.pkl
+model_transformer.pt
+transformer_threshold.json
+```
+
+Future developers adding or replacing models should ensure that:
+
+1. The model artifact is saved in a backend-readable format.
+2. Any scaler or preprocessing object required by the model is also saved.
+3. The backend model registry is updated.
+4. The frontend model selector can display the new model if it is user-facing.
+5. The user guide is updated if the new model changes how users interact with the system.
+
+Generated artifacts should not be committed if they are large or excluded by `.gitignore`.
+
+---
+
+## 8. API Responsibilities
+
+The frontend communicates with the backend through REST endpoints and WebSocket streams.
+
+Common API responsibilities include:
+
+| API area | Responsibility |
+|---|---|
+| Health check | Confirm backend availability |
+| Model list | Return available models |
+| Sample CSV | Provide an example input file |
+| Upload | Validate and stage uploaded CSV data |
+| Prediction | Run anomaly prediction for a selected model |
+| Model comparison | Compare results across multiple models |
+| Report | Generate PDF report output |
+| Replay stream | Stream uploaded CSV prediction results |
+| Live ingest | Receive one live sensor sample |
+| Live config | Update live model or threshold settings |
+| Live stream | Send live prediction updates to the frontend |
+
+When adding or editing APIs, developers should keep responses consistent and return clear error messages that the frontend can display to users.
+
+---
+
+## 9. Data Schema
+
+The final application expects SKAB-format pump sensor data.
+
+Required columns:
+
+```text
+datetime
+Accelerometer1RMS
+Accelerometer2RMS
+Current
+Pressure
+Temperature
+Thermocouple
+Voltage
+Volume Flow RateRMS
+```
+
+Optional label column:
+
+```text
+anomaly
+```
+
+Developers should be careful when changing validation or preprocessing logic because the trained models expect the same sensor order and feature format used during training.
+
+---
+
+## 10. Alert State Logic
+
+The application converts anomaly probabilities into user-friendly alert states.
+
+| State | Meaning |
+|---|---|
+| NORMAL | Low anomaly risk |
+| WATCH | Slight increase in anomaly probability |
+| WARNING | Elevated anomaly risk |
+| ALERT | High anomaly risk |
+
+The alert state logic helps users interpret model output without needing to understand raw probability values. Future changes to thresholding or smoothing should be tested carefully because they affect the user-facing warning behaviour.
+
+---
+
+## 11. Development Workflow
+
+Recommended development workflow:
+
+1. Create a feature branch for each task.
+2. Keep commits small and focused.
+3. Use meaningful commit messages.
+4. Test the affected backend or frontend workflow locally.
+5. Open a pull request before merging.
+6. Request review from at least one team member.
+7. Update documentation if the change affects users, developers, models, or APIs.
+
+Example branch names:
+
+```text
+feature/upload-validation
+feature/live-monitoring-chart
+feature/pdf-report-update
+bugfix/model-loading-error
+docs/developer-guide
+```
+
+Example commit messages:
+
+```text
+feat(upload): improve CSV validation messages
+feat(results): add model comparison summary
+fix(live): handle stale sensor stream
+docs(handover): add developer guide
+test(api): add upload validation test
+```
+
+---
+
+## 12. Testing and Quality Assurance
+
+Future developers should test the relevant part of the system before merging changes.
+
+Recommended checks:
+
+| Area | Checks |
+|---|---|
+| Backend | API response, validation logic, inference logic, report generation |
+| Frontend | Page loading, navigation, form behaviour, charts, buttons, error messages |
+| Upload workflow | Valid CSV, invalid CSV, missing columns, wrong file type |
+| Prediction workflow | Model selection, threshold adjustment, prediction output |
+| Live workflow | Incoming sensor ticks, alert state changes, data-quality warnings |
+| Report workflow | PDF generation and download |
+| Documentation | Update user/developer docs when behaviour changes |
+
+Testing should include both expected behaviour and common failure cases.
+
+---
+
+## 13. Adding a New Model
+
+To add a new model:
+
+1. Train the model using the offline ML pipeline.
+2. Save the model artifact and any required scaler/preprocessor.
+3. Add the artifact to the backend artifacts folder.
+4. Register the model in the backend model-loading logic.
+5. Confirm the model appears in the available model list.
+6. Test prediction with a valid SKAB-format CSV.
+7. Update the frontend model selector if needed.
+8. Update documentation if the model is part of the final user-facing system.
+
+---
+
+## 14. Adding a New Frontend Feature
+
+To add a frontend feature:
+
+1. Create a feature branch.
+2. Add or update the relevant React component.
+3. Connect to the backend API if required.
+4. Add loading, success, and error states.
+5. Test the feature in the browser.
+6. Check that existing upload, results, and live pages still work.
+7. Update documentation if user behaviour changes.
+
+Frontend changes should avoid hiding important errors from the user.
+
+---
+
+## 15. Adding a New Backend Feature
+
+To add a backend feature:
+
+1. Create a feature branch.
+2. Add or update the relevant backend module.
+3. Validate all input data.
+4. Return structured success and error responses.
+5. Add tests where possible.
+6. Confirm the frontend can handle the response.
+7. Update documentation if the API or behaviour changes.
+
+Backend changes should avoid tightly coupling unrelated logic. For example, upload validation, model inference, and report generation should remain separate where possible.
+
+---
+
+## 16. Code Quality Notes
+
+Future development should follow these principles:
+
+- Keep functions small and focused.
+- Use clear names for files, functions, variables, and components.
+- Avoid duplicating validation or preprocessing logic.
+- Keep API responses consistent.
+- Handle errors clearly instead of failing silently.
+- Keep model-specific logic separated from general application logic where possible.
+- Update documentation when implementation changes affect users or developers.
+
+---
+
+## 17. Known Technical Limitations
+
+Known limitations of the current implementation:
+
+- The system is trained and tested on SKAB data only.
+- Real client pump data has not yet been used for validation.
+- The prediction task is binary anomaly detection, not detailed fault diagnosis.
+- The live workflow uses simulated data rather than a real SCADA or PLC connection.
+- Model artifacts are not stored directly in GitHub.
+- There is no user authentication or role-based access control.
+- Prediction history is not persisted in a production database.
+- Further testing is required before operational deployment.
+
+---
+
+## 18. Recommended Future Development
+
+Recommended future improvements:
+
+1. Validate the system using real client pump data.
+2. Add model retraining or recalibration support.
+3. Add explainability to show which sensors influenced predictions.
+4. Add persistent storage for prediction history.
+5. Add authentication if the system is made public.
+6. Integrate with a real industrial data source.
+7. Extend the system from binary anomaly detection to fault-type diagnosis.
+8. Improve model monitoring for drift or degraded performance.
+
+---
+
+## 19. Handover Notes for Future Developers
+
+Before making major changes, future developers should understand:
+
+- The application is designed around SKAB-format pump data.
+- The backend depends on model artifacts being available.
+- The frontend expects clear API responses from the backend.
+- The current live workflow is simulation-based.
+- The system is a capstone prototype and should be validated further before real operational use.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,284 @@
+# pump.detect User Guide
+
+CITS5206 Information Technology Capstone Project — Group 14  
+Predictive Maintenance Anomaly Detection for Centrifugal Pumps
+
+## 1. Purpose
+
+pump.detect is a web application for detecting possible pump anomalies from sensor data. It allows users to upload SKAB-format pump sensor data, run anomaly prediction using trained machine learning models, view anomaly probabilities, monitor simulated live pump data, compare model outputs, and download a PDF report.
+
+This guide explains how to use the application after it has already been started. Setup and deployment instructions are provided separately in the project README and Deployment Guide.
+
+---
+
+## 2. Main Workflows
+
+The application supports two main workflows:
+
+### 2.1 Batch Analysis
+
+The batch analysis workflow is used when a user wants to upload a CSV file and analyse historical pump sensor data.
+
+Main steps:
+
+1. Upload a SKAB-format CSV file.
+2. Select a trained prediction model.
+3. Set the anomaly alert threshold.
+4. Run the prediction or replay.
+5. View anomaly probability and alert status.
+6. Compare model outputs if required.
+7. Download the generated PDF report.
+
+### 2.2 Live Monitoring
+
+The live monitoring workflow is used when a user wants to monitor incoming pump sensor readings in real time.
+
+Main steps:
+
+1. Open the live monitoring page.
+2. View incoming sensor readings.
+3. Monitor anomaly probability and alert state.
+4. Adjust the active model or threshold if required.
+5. Review data-quality warnings if they appear.
+
+For the capstone demonstration, the live monitoring workflow uses simulated pump data rather than a real industrial pump connection.
+
+---
+
+## 3. Accessing the Application
+
+Follow the setup instructions in the project README or Deployment Guide to start the application.
+
+After the application is running, open the web interface in a browser:
+
+```text
+http://localhost:8080
+```
+
+Main pages:
+
+| Page | Purpose |
+|---|---|
+| Home | Shows the project overview and navigation options |
+| Upload | Allows users to upload SKAB-format CSV data and run prediction |
+| Results | Displays prediction outputs, charts, summaries, and model comparison |
+| Live | Shows real-time or simulated pump monitoring |
+
+---
+
+## 4. Required CSV Format
+
+The upload page expects a SKAB-format CSV file.
+
+Required columns:
+
+```text
+datetime
+Accelerometer1RMS
+Accelerometer2RMS
+Current
+Pressure
+Temperature
+Thermocouple
+Voltage
+Volume Flow RateRMS
+```
+
+Optional label column:
+
+```text
+anomaly
+```
+
+If the `anomaly` column is included, the system can calculate labelled evaluation metrics such as precision, recall, and F1 score. If the `anomaly` column is not included, the system will still produce anomaly probabilities and alert states, but labelled evaluation metrics will not be available.
+
+The system accepts CSV files using either comma `,` or semicolon `;` separators.
+
+---
+
+## 5. Uploading a CSV File
+
+To upload a file:
+
+1. Open the application.
+2. Go to the **Upload** page.
+3. Select a valid `.csv` file.
+4. Wait for the file validation result.
+5. If the file is valid, the page will show a success message.
+6. If the file is invalid, the page will show an error message explaining what needs to be fixed.
+
+Common upload issues:
+
+| Issue | Meaning | How to fix |
+|---|---|---|
+| Wrong file type | The uploaded file is not a `.csv` file | Export or save the file as CSV |
+| Missing columns | One or more required SKAB columns are missing | Rename or add the required columns |
+| Empty file | The file has no usable data | Upload a CSV containing headers and sensor rows |
+| Non-numeric values | A sensor column contains text or invalid values | Replace text placeholders with numeric readings |
+| Missing sensor values | A sensor column contains blank or missing values | Fill, interpolate, or remove missing rows |
+| Timestamp error | The `datetime` column cannot be parsed | Use a standard timestamp format such as `2020-03-09 15:56:30` |
+| Too few rows | The file is shorter than the required prediction window | Upload a longer sequence of sensor readings |
+
+---
+
+## 6. Selecting a Model
+
+After a valid CSV file is uploaded, the user can select one of the available trained models.
+
+Available model types include:
+
+| Model | Type |
+|---|---|
+| Logistic Regression | Linear baseline |
+| Random Forest | Tree-based model |
+| Extra Trees | Tree-based ensemble |
+| Gradient Boosting | Boosting model |
+| XGBoost | Boosting model |
+| KNN | Instance-based model |
+| SVM | Support vector machine |
+| TransformerFusionLite | Deep learning model |
+
+The TransformerFusionLite model is the strongest reported model in the final system, with F1 = 0.9244 on the SKAB held-out test set.
+
+---
+
+## 7. Setting the Alert Threshold
+
+The alert threshold controls how confident the model must be before the system marks a prediction as anomalous.
+
+| Threshold setting | Behaviour |
+|---|---|
+| Lower threshold | More sensitive; may detect more anomalies but may produce more false alerts |
+| Balanced threshold | Suitable for general demonstration use |
+| Higher threshold | More conservative; fewer alerts but may miss weaker early signs |
+
+Users can adjust the threshold depending on whether they want the system to prioritise early warning or reduce false alarms.
+
+---
+
+## 8. Running Batch Prediction
+
+After uploading a valid file, selecting a model, and setting the threshold:
+
+1. Click **Run Prediction** or **Start Replay**.
+2. The application processes the uploaded sensor data.
+3. The chart displays anomaly probability over time.
+4. The status banner shows the current alert state.
+5. Summary results are displayed after prediction.
+6. The user can download a PDF report if required.
+
+The system uses recent sensor readings to estimate whether an anomaly is likely.
+
+---
+
+## 9. Alert States
+
+The application uses four alert states:
+
+| State | Meaning |
+|---|---|
+| NORMAL | Low anomaly risk |
+| WATCH | Slight increase in anomaly probability |
+| WARNING | Elevated anomaly risk |
+| ALERT | High anomaly risk |
+
+These alert states help users understand the model output without needing to interpret raw probability values only.
+
+---
+
+## 10. Viewing Results
+
+The results page may include:
+
+- Anomaly probability chart
+- Alert status summary
+- Prediction statistics
+- Model comparison results
+- Anomaly timeline
+- Confusion matrix if labelled data is available
+- Evaluation metrics if labelled data is available
+- PDF report download option
+
+If the uploaded file does not contain the `anomaly` label column, the system will still show predictions, but ground-truth evaluation metrics will not be shown.
+
+---
+
+## 11. Downloading the PDF Report
+
+After prediction is complete:
+
+1. Go to the results section.
+2. Click **Download PDF report**.
+3. Save the generated PDF file locally.
+
+The PDF report provides a shareable summary of the prediction run. It may include the anomaly timeline, model output, model comparison, and key result information.
+
+---
+
+## 12. Using Live Monitoring
+
+The **Live** page displays real-time anomaly monitoring.
+
+For the capstone demonstration, live data is produced by a local pump simulator. Setup instructions for the simulator are provided in the Deployment Guide.
+
+Once the live data source is running, open:
+
+```text
+http://localhost:8080/live
+```
+
+The live page allows users to:
+
+- View incoming pump sensor readings.
+- See anomaly probability update over time.
+- Monitor alert state changes.
+- Change the active model.
+- Adjust the alert threshold.
+- Pause or clear the live display.
+- View data-quality warnings.
+
+Possible data-quality warnings include:
+
+| Warning | Meaning |
+|---|---|
+| FROZEN_SENSOR | A sensor value appears stuck |
+| OUT_OF_RANGE | A sensor value is outside the expected range |
+| UNEVEN_SAMPLING | Incoming samples are not evenly spaced |
+| STALE_DATA | No new sensor ticks have arrived recently |
+
+---
+
+## 13. Interpreting the Output
+
+The system output should be used as a decision-support signal, not as a final maintenance decision by itself.
+
+General interpretation:
+
+| Output | Interpretation |
+|---|---|
+| Low anomaly probability | The current sensor pattern looks similar to normal SKAB pump behaviour |
+| Increasing anomaly probability | The pump pattern may be moving away from normal behaviour |
+| WATCH or WARNING | The user should monitor the system more closely |
+| ALERT | The system has detected a high anomaly risk based on the selected model and threshold |
+
+A high anomaly probability does not explain the exact physical fault. It indicates that the sensor pattern appears abnormal according to the trained model.
+
+---
+
+## 14. Current User Limitations
+
+The current system is a capstone prototype and has the following limitations:
+
+- The models were trained and tested on SKAB data.
+- The system has not yet been validated on real client operational pump data.
+- The current prediction task is binary anomaly detection, not detailed fault diagnosis.
+- The live workflow uses a simulator rather than a real SCADA or PLC connection.
+- Model artifacts must be available in the backend artifacts folder before prediction can run.
+- The system does not currently include user authentication.
+- Prediction history is not currently stored in a production database.
+
+---
+
+## 15. Recommended Use
+
+pump.detect should be used as a demonstration and decision-support prototype for predictive maintenance. Before operational deployment, the system should be tested with real pump sensor data, calibrated for the client environment, and integrated with the client’s live data source.


### PR DESCRIPTION
## Summary

This PR adds the D3 handover documentation for the final project submission.

## Changes

- Added `docs/USER_GUIDE.md`
  - Explains how to use the pump.detect application after it is running.
  - Covers CSV upload, model selection, threshold adjustment, batch prediction, live monitoring, alert states, result interpretation, PDF report download, and current user limitations.

- Added `docs/DEVELOPER_GUIDE.md`
  - Provides technical handover notes for future developers.
  - Covers repository structure, backend and frontend responsibilities, ML pipeline, model artifact integration, API responsibilities, data schema, alert logic, testing expectations, development workflow, and known technical limitations.

## Purpose

These documents support the D3 final project handover by making the system easier for users, markers, and future developers to understand, review, and extend.